### PR TITLE
Added cross-platform binary builds and Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# https://docs.travis-ci.com/user/languages/python/
+language: python
+matrix:
+  include:
+    - name: "Python 3.7 on Linux"
+      python: 3.7
+      dist: xenial
+    - name: "Python 3.7 on macOS"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+    - name: "Python 3.7 on Windows"
+      os: windows
+      language: shell
+      before_install: choco install python
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+install:
+  - pip3 install pyinstaller
+script:
+  - pyinstaller \
+      --clean \
+      --windowed \
+      --onedir \
+      --onefile \
+      --add-data Scripts:Scripts \
+      ProperTree.command

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,4 @@ matrix:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:
   - pip3 install pyinstaller
-script:
-  - pyinstaller \
-      --clean \
-      --windowed \
-      --onedir \
-      --onefile \
-      --add-data Scripts:Scripts \
-      ProperTree.command
+script: pyinstaller --clean --windowed --onedir --onefile --add-data Scripts:Scripts ProperTree.command

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,18 @@ matrix:
     - name: "Python 3.7 on Linux"
       python: 3.7
       dist: xenial
+      install: pip3 install pyinstaller
+      script: pyinstaller --clean --windowed --onedir --onefile --add-data "Scripts:Scripts" ProperTree.command
     - name: "Python 3.7 on macOS"
       os: osx
       osx_image: xcode10.2
       language: shell
+      install: pip3 install pyinstaller
+      script: pyinstaller --clean --windowed --onedir --onefile --add-data "Scripts:Scripts" ProperTree.command
     - name: "Python 3.7 on Windows"
       os: windows
       language: shell
       before_install: choco install python
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
-install:
-  - pip3 install pyinstaller
-script: pyinstaller --clean --windowed --onedir --onefile --add-data Scripts:Scripts ProperTree.command
+      install: pip3 install pyinstaller
+      script: pyinstaller --clean --windowed --onedir --onefile --add-data "Scripts;Scripts" ProperTree.command

--- a/ProperTree.command
+++ b/ProperTree.command
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys, os, binascii, base64
+import queue, json, ctypes # Fix for pyinstaller failing to bundle dependencies
 try:
     import Tkinter as tk
     import ttk

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[![Build Status](https://travis-ci.org/CorpNewt/ProperTree.svg?branch=master)](https://travis-ci.org/CorpNewt/ProperTree)
+[![Build Status](https://travis-ci.org/corpnewt/ProperTree.svg?branch=master)](https://travis-ci.org/corpnewt/ProperTree)
 # ProperTree
 Cross platform GUI plist editor written in python.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Build Status](https://travis-ci.org/CorpNewt/ProperTree.svg?branch=master)](https://travis-ci.org/CorpNewt/ProperTree)
 # ProperTree
 Cross platform GUI plist editor written in python.


### PR DESCRIPTION
Uses `pyinstaller` to build a single-file executable for Linux, macOS and Windows, thanks to Travis CI.

To enable Travis, you just need to go [here](https://travis-ci.org), login with your GitHub account, go to Settings, search for `ProperTree` and toggle the on/off switch next to it. After that, each commit should trigger a build.

You can see a successful sample build output here: https://travis-ci.org/Dids/ProperTree/builds/529411076

Note that this doesn't have any tag/release logic yet, but I can work on that next if you're interested. :)

EDIT: Sorry, missed PR #2, although it has a bit of a different approach.