### PR TITLE
macOS Dark Mode support

### DIFF
--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -2448,4 +2448,4 @@ class PlistWindow(tk.Toplevel):
             self._tree.tag_configure('even', background='systemWindowBackgroundColor1')
         except:
             self._tree.tag_configure('odd', background='#E8E8E8')
-            self._tree.tag_configure('even', background='#505050')
+            self._tree.tag_configure('even', background='#DFDFDF')

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -2441,5 +2441,11 @@ class PlistWindow(tk.Toplevel):
                 pass
             tags.append("odd" if x % 2 else "even")
             self._tree.item(item, tags=tags)
-        self._tree.tag_configure('odd', background='#E8E8E8')
-        self._tree.tag_configure('even', background='#DFDFDF')
+
+        try:
+            # MacOS colors which change value when Dark Mode is enabled
+            self._tree.tag_configure('odd', background='systemWindowBackgroundColor')
+            self._tree.tag_configure('even', background='systemWindowBackgroundColor1')
+        except:
+            self._tree.tag_configure('odd', background='#E8E8E8')
+            self._tree.tag_configure('even', background='#505050')


### PR DESCRIPTION
Replace hardcoded background colors with macOS named colors from ttk, which will change according to light/dark mode