### PR TITLE
Fix hacky imports causing clash with libplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ git clone https://github.com/corpnewt/ProperTree
 
   This shouldn't happen and it is recommended that you download only from the official ProperTree repository, but if you are confident about your source, then running `chmod +x ProperTree.command` should sort it out
 
-* **I'm on an Arch-based distro with python 3 and I get `TypeError: expected bytes, str found` when trying to copy or save**
-
-  This is a known issue with `libplist` on Arch-based distros (discussed [here](https://github.com/corpnewt/ProperTree/issues/19)).  Current solutions are to use python 2, or to remove `libplist`.
-  
 * **I use an international keyboard layout on macOS and some keys crash ProperTree with `NSRangeException', reason: '-[__NSCFConstantString characterAtIndex:]: Range or index out of bounds`**
 
   This is a bug in the Cocoa implementation of Tcl/Tk on macOS (discussed [here](https://bugs.python.org/issue22566)).  The latest python 2 installer from [python.org](https://www.python.org/downloads/release/python-2718/) ships with, and uses Tcl/Tk 8.6.8 which has this issue fixed.  Given that the shebang in `ProperTree.command` leverages `#!/usr/bin/env python` - the first python 2 binary found should be used.

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -15,8 +15,7 @@ except ImportError:
     from tkinter import filedialog as fd
     from tkinter import messagebox as mb
     from itertools import zip_longest as izip
-sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
-import plist
+from . import plist
 
 try:
     long


### PR DESCRIPTION
The bare `import plist` in `Scripts/plistwindow.py` was supposed to import the `plist.py` module in the same (`Scripts`) package. However, if the `libplist` package was installed on the system, it actually imported the system's `plist.so`.

This kind of import (`import X` to import the module X in the same package) is called _implicit relative import_ and according to PEP8, it should _never_ be used. It isn't even supposed to work anymore in Python 3, but in this case, there was a hack to emulate it by adding the current package to the search path, making it a global import. However, the system packages took precedence.

I replaced it with a relative import.

I've tested that it works with both Python 2(.7) and 3(.8).

This should correctly fix #19, #22, #28, #31, without people having to remove their libplist system package.