### PR TITLE
Use python3 by default

### DIFF
--- a/ProperTree.command
+++ b/ProperTree.command
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, os, binascii, base64, json, re, subprocess
 from collections import OrderedDict
 try:


### PR DESCRIPTION
First of all - fixes issue #66 
Second - python 3 is now the only officially supported

This should not conflict with anything :)

Thank you for your awesome work Newt <3