### PR TITLE
Fix crash when min_tk==None

### DIFF
--- a/Scripts/buildapp-select.command
+++ b/Scripts/buildapp-select.command
@@ -80,7 +80,7 @@ def select_py(py_versions,min_tk,pt_current):
                 x[0],
                 " {}".format(x[1]) if x[1] else "",
                 " - tk {}".format(x[2]) if x[2] else "",
-                "" if x[2]==None or x[2] >= min_tk else " ({}+ recommended)".format(min_tk),
+                "" if x[2]==None or min_tk!=None and x[2] >= min_tk else " ({}+ recommended)".format(min_tk),
             ))
         print("")
         if current: print("C. Current ({})".format(current))


### PR DESCRIPTION
Output on run before:
>  - Currently Available Python Versions -
> 
> An error occurred!
> '>=' not supported between instances of 'str' and 'NoneType'
Fixed by checking that min_tk!=None. Output on run after:
>  - Currently Available Python Versions -
> 
> 1. /usr/bin/python 2.7.16 - tk 8.5 (None+ recommended)
> 2. /usr/local/opt/python/libexec/bin/python 3.9.1 - tk 8.6 (None+ recommended)
> 3. /usr/bin/python3 3.8.2 - tk 8.5 (None+ recommended)
> 4. /usr/local/bin/python3 3.9.1 - tk 8.6 (None+ recommended)
> 5. /usr/bin/env python
> 6. /usr/bin/env python3
> 
> Q. Quit
> 
> Please select the python version to use:  
... and the .app builds/works correctly.