### PR TITLE
Implement custom font

### DIFF
--- a/ProperTree.command
+++ b/ProperTree.command
@@ -126,7 +126,7 @@ class ProperTree:
 
         # Custom font picker - wacky implementation.
         self.font_var = tk.IntVar()
-        self.font_family  = tk.StringVar(self.settings_window)
+        self.font_family  = tk.StringVar()
         self.font_custom_check = tk.Checkbutton(self.settings_window,text="Use Custom Font",variable=self.font_var,command=self.font_select)
         self.font_custom = ttk.Combobox(self.settings_window,state="readonly",textvariable=self.font_family,values=sorted(families()))
         self.font_custom.bind('<<ComboboxSelected>>',self.font_pick)
@@ -923,10 +923,7 @@ class ProperTree:
         c = root.children
         s = root.tk.eval('wm stackorder {}'.format(root))
         L = [x.lstrip('.') for x in s.split()]
-        for x in L:
-            if x == '!toplevel.!combobox.popdown':
-                L.remove('!toplevel.!combobox.popdown')
-        return [(c[x] if x else root) for x in L]
+        return [(c[x] if x else root) for x in L if x in c or not x]
 
     def lift_window(self, window):
         window.lift()

--- a/ProperTree.command
+++ b/ProperTree.command
@@ -465,7 +465,6 @@ class ProperTree:
         if self.settings["font_family"] == font_family:
             return
         self.settings["font_family"] = font_family
-        # self.font_family.set(font_family)
         self.update_font_family()
 
     def update_font(self, var = None, blank = None, trace_mode = None):

--- a/ProperTree.command
+++ b/ProperTree.command
@@ -128,7 +128,7 @@ class ProperTree:
         self.font_var = tk.IntVar()
         self.font_family  = tk.StringVar(self.settings_window)
         self.font_custom_check = tk.Checkbutton(self.settings_window,text="Use Custom Font",variable=self.font_var,command=self.font_select)
-        self.font_custom = ttk.Combobox(self.settings_window,textvariable=self.font_family,values=sorted(families()))
+        self.font_custom = ttk.Combobox(self.settings_window,state="readonly",textvariable=self.font_family,values=sorted(families()))
         self.font_custom.bind('<<ComboboxSelected>>',self.font_pick)
         self.font_family.trace("w",self.update_font_family)
         self.font_custom_check.grid(row=21,column=0,stick="w",padx=10)
@@ -453,7 +453,7 @@ class ProperTree:
         if self.font_var.get():
             self.settings["use_custom_font"] = True
             self.settings["font_family"] = self.font_family.get()
-            self.font_custom.configure(state='normal')
+            self.font_custom.configure(state='readonly')
         else:
             self.settings["use_custom_font"] = False
             self.font_custom.configure(state='disabled')
@@ -461,10 +461,11 @@ class ProperTree:
         self.update_font_family()
 
     def font_pick(self, event = None):
-        if self.settings["font_family"] == event.widget.get():
+        font_family = self.font_family.get()
+        if self.settings["font_family"] == font_family:
             return
-        self.settings["font_family"] = event.widget.get()
-        self.font_family.set(event.widget.get())
+        self.settings["font_family"] = font_family
+        # self.font_family.set(font_family)
         self.update_font_family()
 
     def update_font(self, var = None, blank = None, trace_mode = None):

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -42,6 +42,7 @@ class EntryPopup(tk.Entry):
         self.column = column
         self.parent = parent
         self.master = master
+        self['font'] = Font(font=self.master.font)
 
         self.focus_force()
         
@@ -292,7 +293,7 @@ class PlistWindow(tk.Toplevel):
         self._tree.heading("#0", text="Key")
         self._tree.heading("#1", text="Type")
         self._tree.heading("#2", text="Value")
-        self._tree.column("Type",width=100,stretch=False)
+        self._tree.column("Type",width=round(self._tree.winfo_reqwidth()/4),stretch=False)
         # self._tree.column("Drag",minwidth=40,width=40,stretch=False,anchor="center")
 
         # Setup the initial colors

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -283,6 +283,7 @@ class PlistWindow(tk.Toplevel):
         # Fix font height for High-DPI displays
         self.font = Font(font='TkTextFont')
         self.set_font_size()
+        self.set_font_family()
 
         # Create the treeview
         self._tree_frame = tk.Frame(self)
@@ -448,6 +449,15 @@ class PlistWindow(tk.Toplevel):
     def set_font_size(self):
         self.font["size"] = self.controller.font_string.get() if self.controller.custom_font.get() else self.controller.default_font["size"]
         self.style.configure(self.style_name, font=self.font, rowheight=int(math.ceil(self.font.metrics()['linespace']*(1.125 if str(sys.platform)=="darwin" else 1.3))))
+
+    def set_font_family(self):
+        if self.controller.font_var.get() == 0:
+            self.font = Font(font="TkTextFont")
+        elif len(self.controller.font_family.get()) > 0:
+            self.font = Font(family=self.controller.font_family.get())
+
+        self.style.configure(self.style_name, font=self.font)
+        self.set_font_size() # Necessary because turning off 'custom font' option seems to fallback to font_size of '9'.
 
     def window_resize(self, event=None, obj=None):
         if not event or not obj: return

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -293,7 +293,7 @@ class PlistWindow(tk.Toplevel):
         self._tree.heading("#0", text="Key")
         self._tree.heading("#1", text="Type")
         self._tree.heading("#2", text="Value")
-        self._tree.column("Type",width=round(self._tree.winfo_reqwidth()/4),stretch=False)
+        self._tree.column("Type",width=int(self._tree.winfo_reqwidth()/4),stretch=False)
         # self._tree.column("Drag",minwidth=40,width=40,stretch=False,anchor="center")
 
         # Setup the initial colors


### PR DESCRIPTION
This PR implements a `custom_font_family` functionality — you are now able to set up a custom font for the editor, if you wish. Works with python2 and python3, doesn't meddle with any other functionality that was there before-hand – simply adds onto the currently existing window.

Platforms/OS versions this has been tested on, where there have been no bugs/issues:

- Ubuntu (20.04 LTS); **Python-2.7** & **Python-3.9.6**;
- Manjaro (XFCE 21.1.1); **Python-2.7** & **Python-3.9.6**;
- FedoraOS (Workstation 34); **Python-2.7** & **Python-3.9.6**;
- Windows 11 (Dev channel – latest); **Python-2.X** & **Python-3.9.6**;
- Windows 10 (21H1); **Python-2.X** & **Python-3.9.6**;
- Big Sur (11.5.2); **Python-2.X** & **Python-3.9.6**;
- Monterey (Beta 5); **Python-3.9.6**