### PR TITLE
Boolean display value changes weren’t being updated in realtime

### DIFF
--- a/ProperTree.py
+++ b/ProperTree.py
@@ -639,10 +639,18 @@ class ProperTree:
 
     def change_bool_type(self, event = None):
         self.settings["display_bool_as"] = self.bool_type_string.get()
+        self.update_bool_type()
 
     def change_snapshot_version(self, event = None):
         self.settings["snapshot_version"] = self.snapshot_string.get().split(" ")[0]
 
+    def update_bool_type(self, event = None, blank = None, trace_mode = None):
+        windows = self.stackorder(self.tk)
+        if not len(windows): return
+        for window in windows:
+            if window in self.default_windows: continue
+            window.change_bool_type(self.bool_type_string.get())
+        
     def font_command(self, event = None):
         if self.custom_font.get():
             self.settings["use_custom_font_size"] = True


### PR DESCRIPTION
Recently, I’ve noticed that ProperTree does not apply changes when selecting a new boolean display value type (i.e. from `True/False` -> `Yes/On`), it does apply the changes to `settings.json` (which are applied upon restarting the app), but it does not update the window accordingly in realtime.

This PR fixes that issue by adding a new function inside of `ProperTree.py` called `update_bool_type()` – which actively updates the boolean type values for all Tk windows opened when a change has been detected.

If it is ideal for the application to only update the current window – I will begin working on a solution that priorities that. 