### PR TITLE
Remove capital in import tkinter as tk

### DIFF
--- a/ProperTree.py
+++ b/ProperTree.py
@@ -2,7 +2,7 @@
 import sys, os, binascii, base64, json, re, subprocess, webbrowser, multiprocessing, signal, ctypes
 from collections import OrderedDict
 try:
-    import Tkinter as tk
+    import tkinter as tk
     import ttk
     import tkFileDialog as fd
     import tkMessageBox as mb


### PR DESCRIPTION
The import text with a capital letter could cause issues if the capital letter isn't removed, Not sure though, however I have heard of issues being caused by capital letters in "import <module>" context