### PR TITLE
Move from recursive to iterative functions and implement boolean locks

### DIFF
--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -3489,7 +3489,7 @@ class PlistWindow(tk.Toplevel):
             current_item = ""
         node_stack = deque()
         node_stack.append(current_item)
-        items = []
+        items = deque()
         while node_stack:
             node = node_stack.pop()
             if node and node != current_item:
@@ -3497,7 +3497,7 @@ class PlistWindow(tk.Toplevel):
             if not visible or self._tree.item(node,"open") or node == "":
                 for child in self._tree.get_children(node)[::-1]:
                     node_stack.append(child)
-        return items
+        return list(items)
 
     def get_root_node(self):
         children = self._tree.get_children("")

--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -297,6 +297,7 @@ class PlistWindow(tk.Toplevel):
         self.saving = False
         self.adding_rows = False
         self.pasting_nodes = False
+        self.alternating_colors = False
         self.reundoing = False
         self.last_data = None
         self.last_int  = None
@@ -3551,6 +3552,8 @@ class PlistWindow(tk.Toplevel):
         self.alternate_colors()
 
     def alternate_colors(self, event = None):
+        if self.alternating_colors: return
+        self.alternating_colors = True
         # Let's walk the children of our treeview
         visible = self.iter_nodes(True,event)
         for x,item in enumerate(visible):
@@ -3563,6 +3566,7 @@ class PlistWindow(tk.Toplevel):
             else:
                 tags.append("odd" if x % 2 else "even")
             self._tree.item(item, tags=tags)
+        self.alternating_colors = False
 
     def show_config_info(self, event = None):
         # find the path of selected cell


### PR DESCRIPTION
This should hopefully fix some issues with exceeding the max recursion depth when spamming paste/new row/undo/redo events by reworking `add_node()`, `nodes_to_values()`, and `iter_nodes()` to be iterative, and using some simple boolean locks when creating rows, pasting data, undoing/redoing, and alternating rows.

`iter_nodes()` also now uses a `deque()`, and casts it as a `list()` before returning - hopefully that should yield some speed improvements.