### PR TITLE
Fixed everything being expanded when performing a snapshot

### DIFF
--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -2172,6 +2172,11 @@ class PlistWindow(tk.Toplevel):
         self.add_undo(undo_list)
         # Select the root element
         self.select(self.get_root_node())
+        # Close if need be
+        if not self.controller.settings.get("expand_all_items_on_open",True):
+            self.collapse_all()
+            # Ensure the root is expanded
+            self._tree.item(self.get_root_node(),open=True)
         # Ensure we're edited
         self._ensure_edited()
         self.update_all_children()


### PR DESCRIPTION
If `Expand Children When Opening Plist` is enabled, ProperTree closes everything but root by default. But, when OC snapshot happens, this option is completely ignored. The fix causes the app to flash for split second when performing a snapshot, but it fixes the issue.