### PR TITLE
Adds HiDPI support for Windows Vista+

### DIFF
--- a/ProperTree.py
+++ b/ProperTree.py
@@ -23,6 +23,13 @@ except NameError:  # Python 3
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from Scripts import plist, plistwindow, downloader
 
+# HiDPI fix for Windows 10/11
+if os.name == 'nt':
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except:
+        pass
+
 def _check_for_update(queue, version_url = None, user_initiated = False):
     args = [sys.executable]
     file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),"Scripts","update_check.py")

--- a/ProperTree.py
+++ b/ProperTree.py
@@ -23,13 +23,6 @@ except NameError:  # Python 3
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from Scripts import plist, plistwindow, downloader
 
-# HiDPI fix for Windows 10/11
-if os.name == 'nt':
-    try:
-        ctypes.windll.shcore.SetProcessDpiAwareness(1)
-    except:
-        pass
-
 def _check_for_update(queue, version_url = None, user_initiated = False):
     args = [sys.executable]
     file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),"Scripts","update_check.py")
@@ -86,6 +79,12 @@ class ProperTree:
         self.queue = multiprocessing.Queue()
         self.tex_queue = multiprocessing.Queue()
         self.creating_window = False
+        # HiDPI fix for Windows
+        if os.name == "nt":
+            try:  # >= win 8.1
+                ctypes.windll.shcore.SetProcessDpiAwareness(2)
+            except:  # win 8.0 or less
+                ctypes.windll.user32.SetProcessDPIAware()
         # Create the new tk object
         self.tk = tk.Tk()
         self.tk.withdraw() # Try to remove before it's drawn

--- a/Scripts/config_tex_info.py
+++ b/Scripts/config_tex_info.py
@@ -109,12 +109,6 @@ def display_info_window(config_tex, search_list, width, valid_only, show_urls, c
 
     # Madness to get the titlebar height
     offset_y = 0
-    if os.name == "nt":
-        import ctypes
-        try:  # >= win 8.1
-            ctypes.windll.shcore.SetProcessDpiAwareness(2)
-        except:  # win 8.0 or less
-            ctypes.windll.user32.SetProcessDPIAware()
     offset_y = int(info_window.geometry().rsplit('+', 1)[-1])
     bar_height = info_window.winfo_rooty() - offset_y
 


### PR DESCRIPTION
When using Windows with scaling 125% or higher the text looks blurry, this PR fixes that.

Before:
<img width="915" height="1380" alt="no dpi" src="https://github.com/user-attachments/assets/647a6a41-103d-4ec7-8ffd-ca023c2a3d89" />

After:
<img width="904" height="1380" alt="dpi aware" src="https://github.com/user-attachments/assets/a14b7133-a188-4e7d-af0e-9c14690aaf21" />

