### PR TITLE
Fix right-click menu not triggering on some macOS setups

### DIFF
--- a/Scripts/plistwindow.py
+++ b/Scripts/plistwindow.py
@@ -605,6 +605,7 @@ class PlistWindow(tk.Toplevel):
         # Bind right click
         if str(sys.platform) == "darwin":
             self._tree.bind("<ButtonRelease-2>", self.popup) # ButtonRelease-2 on mac
+            self._tree.bind("<ButtonRelease-3>", self.popup) # ButtonRelease-3 on mac
             self._tree.bind("<Control-ButtonRelease-1>", self.popup) # Ctrl+Left Click on mac
         else:
             self._tree.bind("<ButtonRelease-3>", self.popup)


### PR DESCRIPTION
On macOS, the right-click event can sometimes be mapped to Button-3 instead of the traditional Button-2, depending on
  mouse hardware and system settings. This PR adds a binding for <ButtonRelease-3> alongside <ButtonRelease-2> to ensure the
  context menu triggers consistently across different setups.